### PR TITLE
Monk X: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,21 @@
 FROM alpine:latest
 
-MAINTAINER JG <julien@mangue.eu>
+LABEL maintainer='JG <julien@mangue.eu>'
 
 RUN apk add --no-cache \
     curl \
     git \
     openssh-client \
-    rsync
+    rsync 
 
 ENV VERSION 0.55.0
+
 RUN mkdir -p /usr/local/src \
     && cd /usr/local/src \
-
-    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_linux-64bit.tar.gz | tar -xz \
+    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz | tar -xz \
     && mv hugo /usr/local/bin/hugo \
-
-    && curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz \
-    && mv minify /usr/local/bin/ \
-
-    && addgroup -Sg 1000 hugo \
-    && adduser -SG hugo -u 1000 -h /src hugo
+    && chown 1000:1000 /usr/local/bin/hugo \
+    && chmod 755 /usr/local/bin/hugo \
 
 WORKDIR /src
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO docker-hugo
+LOAD docker-hugo.yaml

--- a/docker-hugo.yaml
+++ b/docker-hugo.yaml
@@ -1,0 +1,28 @@
+namespace: docker-hugo
+docker-hugo:
+  defines: runnable
+  metadata:
+    name: docker-hugo
+    description: >-
+      A Hugo (a static site generator written in Go) Docker image ready for
+      continuous integration. It also includes builds with pygments support and
+      plenty of useful features for CI/CD
+    icon: https://emojiapi.dev/api/v1/whale.svg
+  containers:
+    docker-hugo:
+      build: .
+      dockerfile: Dockerfile
+  services:
+    hugo-server:
+      container: docker-hugo
+      port: 1313
+      host-port: 1313
+      publish: false
+      protocol: TCP
+      description: Hugo server port
+  variables:
+    version:
+      env: VERSION
+      type: string
+      description: Hugo version to be used
+      value: '0.55'


### PR DESCRIPTION
I couldn't make the /tmp/lmsv/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
Uploading context file...
Building image...
Failed to build image: image service build failed

```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.