### PR TITLE
Monk X: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,32 @@
 FROM alpine:latest
 
-MAINTAINER JG <julien@mangue.eu>
+LABEL maintainer="JG <julien@mangue.eu>"
 
 RUN apk add --no-cache \
     curl \
     git \
     openssh-client \
-    rsync
+    rsync \
+    openssh \
+    tar
 
-ENV VERSION 0.55.0
+ENV VERSION=0.55.6
+
 RUN mkdir -p /usr/local/src \
     && cd /usr/local/src \
-
-    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_linux-64bit.tar.gz | tar -xz \
+    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz | tar -xz \
     && mv hugo /usr/local/bin/hugo \
 
-    && curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz \
-    && mv minify /usr/local/bin/ \
+RUN curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz \
+    && mv minify /usr/local/bin/
 
-    && addgroup -Sg 1000 hugo \
-    && adduser -SG hugo -u 1000 -h /src hugo
+RUN addgroup -g 1000 hugo \
+    && adduser -u 1000 -G hugo -s /bin/sh -D hugo
 
 WORKDIR /src
 
 EXPOSE 1313
+
+USER hugo
+
+CMD ["hugo"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO hugo-docker-image
+LOAD hugo-docker-image.yaml

--- a/hugo-docker-image.yaml
+++ b/hugo-docker-image.yaml
@@ -1,0 +1,27 @@
+namespace: hugo-docker-image
+hugo-docker-image:
+  defines: runnable
+  metadata:
+    name: hugo-docker-image
+    description: >-
+      A lightweight Docker image based on Alpine, used for running Hugo - a fast
+      and flexible static site generator written in Go.
+    icon: https://emojiapi.dev/api/v1/whale.svg
+  containers:
+    hugo-docker-image:
+      build: .
+      dockerfile: Dockerfile
+  services:
+    hugo-server:
+      container: hugo-docker-image
+      port: 1313
+      host-port: 1313
+      publish: false
+      protocol: TCP
+      description: Hugo server's port for viewing the static site locally
+  variables:
+    version:
+      env: VERSION
+      type: string
+      description: Version of Hugo to be installed
+      value: 0.55.0


### PR DESCRIPTION
I couldn't make the /tmp/dbas3w/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
Uploading context file...
Building image...
Failed to build image: image service build failed

```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.